### PR TITLE
Fail if source and destination file is the same

### DIFF
--- a/lib/html2slim/command.rb
+++ b/lib/html2slim/command.rb
@@ -85,6 +85,8 @@ module HTML2Slim
       else
         slim_file = destination || slim_file
       end
+      
+      fail(ArgumentError, "Source and destination files can't be the same.") if file == slim_file
 
       in_file = if @options[:input] == "-"
         $stdin

--- a/lib/html2slim/command.rb
+++ b/lib/html2slim/command.rb
@@ -86,7 +86,7 @@ module HTML2Slim
         slim_file = destination || slim_file
       end
       
-      fail(ArgumentError, "Source and destination files can't be the same.") if file == slim_file
+      fail(ArgumentError, "Source and destination files can't be the same.") if @options[:input] != '-' && file == slim_file
 
       in_file = if @options[:input] == "-"
         $stdin


### PR DESCRIPTION
This avoids the case when you use erb2slim with a slim file as parameter.
What happens before this: slim file gets blank.
Now: Error is raised