### PR TITLE
Fixed malformed slim generation with empty class or id attributes

### DIFF
--- a/lib/html2slim/hpricot_monkeypatches.rb
+++ b/lib/html2slim/hpricot_monkeypatches.rb
@@ -44,6 +44,8 @@ class Hpricot::DocType
 end
 
 class Hpricot::Elem
+  BLANK_RE = /\A[[:space:]]*\z/
+
   def slim(lvl=0)
     r = '  ' * lvl
 
@@ -97,11 +99,11 @@ class Hpricot::Elem
   end
 
   def has_id?
-    has_attribute?('id')
+    has_attribute?('id') && !(BLANK_RE === self['id'])
   end
 
   def has_class?
-    has_attribute?('class')
+    has_attribute?('class') && !(BLANK_RE === self['class'])
   end
 
   def ruby?

--- a/test/fixtures/div_with_class_without_id.html
+++ b/test/fixtures/div_with_class_without_id.html
@@ -1,0 +1,1 @@
+<div id="" class="test"></div>

--- a/test/fixtures/div_with_class_without_id.slim
+++ b/test/fixtures/div_with_class_without_id.slim
@@ -1,0 +1,1 @@
+div.test

--- a/test/fixtures/div_with_id_without_class.html
+++ b/test/fixtures/div_with_id_without_class.html
@@ -1,0 +1,1 @@
+<div id="test" class=""></div>

--- a/test/fixtures/div_with_id_without_class.slim
+++ b/test/fixtures/div_with_id_without_class.slim
@@ -1,0 +1,1 @@
+div#test


### PR DESCRIPTION
Fixed issue when converting:
```html
<tag id="" class="">Text</tag>
```
to:
```slim
tag#. Text
```
