### PR TITLE
Fixed issue of the wrong conversion of the leading dashed end.

### DIFF
--- a/lib/html2slim/converter.rb
+++ b/lib/html2slim/converter.rb
@@ -26,7 +26,7 @@ module HTML2Slim
       erb.gsub!(/<%-?\s*(elsif .+?)\s*-?%>/){ %(</ruby><ruby code="#{$1.gsub(/"/, '&quot;')}">) }
       # when
       erb.gsub!(/<%-?\s*(when .+?)\s*-?%>/){ %(</ruby><ruby code="#{$1.gsub(/"/, '&quot;')}">) }
-      erb.gsub!(/<%\s*(end|}|end\s+-)\s*%>/, %(</ruby>))
+      erb.gsub!(/<%-?\s*(end|}|end\s+-)\s*%>/, %(</ruby>))
       erb.gsub!(/<%(.+?)\s*-?%>/m){ %(<ruby code="#{$1.gsub(/"/, '&quot;')}"></ruby>) }
       @slim ||= Hpricot(erb).to_slim
     end

--- a/test/fixtures/erb_end.erb
+++ b/test/fixtures/erb_end.erb
@@ -1,0 +1,6 @@
+<% if true %>
+  <p>hoge</p>
+<%- end %>
+<% if true %>
+  <p>fuga</p>
+<%- end -%>

--- a/test/fixtures/erb_end.slim
+++ b/test/fixtures/erb_end.slim
@@ -1,0 +1,6 @@
+- if true
+  p
+    | hoge
+- if true
+  p
+    | fuga

--- a/test/test_html2slim.rb
+++ b/test/test_html2slim.rb
@@ -84,6 +84,12 @@ class TestHTML2Slim < MiniTest::Test
     assert_html_to_slim html, slim
   end
 
+  def test_convert_leading_dashes_end
+    IO.popen("bin/erb2slim test/fixtures/erb_end.erb -", "r") do |f|
+      assert_equal File.read("test/fixtures/erb_end.slim"), f.read
+    end
+  end
+
   def test_erb_tags
     # simple
     assert_erb_to_slim '<% a = 1 %>', '- a = 1'


### PR DESCRIPTION
For example:

```erb
<% if true %>
  <p>hoge</p>
<%- end %>
```

```erb2slim``` command outputs a following wrong slim file.

```slim
- if true
  p
    | hoge
  - - end
```