### PR TITLE
Fix issue that would unescape html entities.

### DIFF
--- a/lib/html2slim/hpricot_monkeypatches.rb
+++ b/lib/html2slim/hpricot_monkeypatches.rb
@@ -20,7 +20,11 @@ class Hpricot::BogusETag
 end
 
 class Hpricot::Text
-  include SlimText
+  def to_slim(lvl=0)
+    str = content.to_s
+    return nil if str.strip.empty?
+    ('  ' * lvl) + %(| #{str.gsub(/\s+/, ' ')})
+  end
 end
 
 class Hpricot::Comment

--- a/test/fixtures/slim-lang.slim
+++ b/test/fixtures/slim-lang.slim
@@ -130,15 +130,15 @@ html[xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en"]
               | render
             span.string
               | 'footer'
-            |  | Copyright © #{year} #{author} 
+            |  | Copyright &copy; #{year} #{author} 
       p.foot.up
         |  Source: 
         a[href="http://github.com/slim-template/slim"]
           | slim-template/slim
-        |  | Slim maintained by 
+        | &nbsp;|&nbsp;Slim maintained by 
         a[href="http://github.com/minad"]
           | minad
-        |  | Logo & design by 
+        | &nbsp;|&nbsp;Logo &amp; design by 
         a[href="http://github.com/activestylus"]
           | activestylus
         br

--- a/test/test_html2slim.rb
+++ b/test/test_html2slim.rb
@@ -84,6 +84,12 @@ class TestHTML2Slim < MiniTest::Test
     assert_html_to_slim html, slim
   end
 
+  def test_escaped_text
+    text = "this is js code sample.&nbsp; &raquo; &lt;script&gt;alert(0)&lt;/script&gt;"
+    assert_html_to_slim text, "| #{text}"
+    assert_erb_to_slim text, "| #{text}"
+  end
+
   def test_erb_tags
     # simple
     assert_erb_to_slim '<% a = 1 %>', '- a = 1'


### PR DESCRIPTION
For example,

```html
&lt;script&gt;alert(0)&lt;/script&gt;
```

run ```html2slim```.

```slim
| <script>alert(0)</script>
```

The above slim is convert to the follow html.

```html
<script>alert(0)</script>
```

It executes the javascript code.