### PR TITLE
Fixed issue of the wrong conversion of the leading dashed something

### DIFF
--- a/lib/html2slim/converter.rb
+++ b/lib/html2slim/converter.rb
@@ -27,7 +27,7 @@ module HTML2Slim
       # when
       erb.gsub!(/<%-?\s*(when .+?)\s*-?%>/){ %(</ruby><ruby code="#{$1.gsub(/"/, '&quot;')}">) }
       erb.gsub!(/<%\s*(end|}|end\s+-)\s*%>/, %(</ruby>))
-      erb.gsub!(/<%(.+?)\s*-?%>/m){ %(<ruby code="#{$1.gsub(/"/, '&quot;')}"></ruby>) }
+      erb.gsub!(/<%-?(.+?)\s*-?%>/m){ %(<ruby code="#{$1.gsub(/"/, '&quot;')}"></ruby>) }
       @slim ||= Hpricot(erb).to_slim
     end
   end

--- a/test/test_html2slim.rb
+++ b/test/test_html2slim.rb
@@ -86,29 +86,29 @@ class TestHTML2Slim < MiniTest::Test
 
   def test_erb_tags
     # simple
-    assert_erb_to_slim '<% a = 1 %>', '- a = 1'
+    assert_erb_to_slim_with_and_without_leading_dash '<% a = 1 %>', '- a = 1'
     # simple = (puts)
     assert_erb_to_slim '<%= @a.b %>', '= @a.b'
     # no block
-    assert_erb_to_slim '<% @a %>SOME<% @b %>', "- @a\n| SOME\n- @b"
+    assert_erb_to_slim_with_and_without_leading_dash '<% @a %>SOME<% @b %>', "- @a\n| SOME\n- @b"
     # block with do
-    assert_erb_to_slim '<% @a.each do |yay| %>SOME<% yay %><% end %>', "- @a.each do |yay|\n  | SOME\n  - yay"
+    assert_erb_to_slim_with_and_without_leading_dash '<% @a.each do |yay| %>SOME<% yay %><% end %>', "- @a.each do |yay|\n  | SOME\n  - yay"
     # block with { and on var
-    assert_erb_to_slim '<% @a.each { |yay| %>SOME<% yay %><% } %>', "- @a.each do |yay|\n  | SOME\n  - yay"
+    assert_erb_to_slim_with_and_without_leading_dash '<% @a.each { |yay| %>SOME<% yay %><% } %>', "- @a.each do |yay|\n  | SOME\n  - yay"
     # block without vars
-    assert_erb_to_slim '<% 10.times { %>SOME<% yay %><% } %>', "- 10.times do\n  | SOME\n  - yay"
+    assert_erb_to_slim_with_and_without_leading_dash '<% 10.times { %>SOME<% yay %><% } %>', "- 10.times do\n  | SOME\n  - yay"
     # if
-    assert_erb_to_slim '<% if 1 == 1 %>SOME<% yay %><% end %>', "- if 1 == 1\n  | SOME\n  - yay"
+    assert_erb_to_slim_with_and_without_leading_dash '<% if 1 == 1 %>SOME<% yay %><% end %>', "- if 1 == 1\n  | SOME\n  - yay"
     # else
-    assert_erb_to_slim '<% if 1 == 1 %>SOME<% yay %><% else %>OTHER<% end %>', "- if 1 == 1\n  | SOME\n  - yay\n- else\n  | OTHER"
+    assert_erb_to_slim_with_and_without_leading_dash '<% if 1 == 1 %>SOME<% yay %><% else %>OTHER<% end %>', "- if 1 == 1\n  | SOME\n  - yay\n- else\n  | OTHER"
     # elsif
-    assert_erb_to_slim '<% if 1 == 1 %>SOME<% yay %><% elsif 2 == 2 %>OTHER<% end %>', "- if 1 == 1\n  | SOME\n  - yay\n- elsif 2 == 2\n  | OTHER"
+    assert_erb_to_slim_with_and_without_leading_dash '<% if 1 == 1 %>SOME<% yay %><% elsif 2 == 2 %>OTHER<% end %>', "- if 1 == 1\n  | SOME\n  - yay\n- elsif 2 == 2\n  | OTHER"
     # case/when
-    assert_erb_to_slim '<% case @foo %><% when 1 %>1<% when 2 %>2<% else %>3<% end %>', "- case @foo\n- when 1\n  | 1\n- when 2\n  | 2\n- else\n  | 3"
+    assert_erb_to_slim_with_and_without_leading_dash '<% case @foo %><% when 1 %>1<% when 2 %>2<% else %>3<% end %>', "- case @foo\n- when 1\n  | 1\n- when 2\n  | 2\n- else\n  | 3"
     # while
-    assert_erb_to_slim '<% while @foo.next %>NEXT<% end %>', "- while @foo.next\n  | NEXT"
+    assert_erb_to_slim_with_and_without_leading_dash '<% while @foo.next %>NEXT<% end %>', "- while @foo.next\n  | NEXT"
     # all togheter and mixed
-    assert_erb_to_slim '<% while @foo.next %><% if 1 == 1 %><% for i in @foo.bar %>WORKS<% end %><% end %><% end %>', "- while @foo.next\n  - if 1 == 1\n    - for i in @foo.bar\n      | WORKS"
+    assert_erb_to_slim_with_and_without_leading_dash '<% while @foo.next %><% if 1 == 1 %><% for i in @foo.bar %>WORKS<% end %><% end %><% end %>', "- while @foo.next\n  - if 1 == 1\n    - for i in @foo.bar\n      | WORKS"
     # unless
     assert_erb_to_slim_with_and_without_leading_dash '<% unless @foo.done? %>NEXT<% end %>',
                                                      "- unless @foo.done?\n  | NEXT"


### PR DESCRIPTION
For example:
```ruby
<%- a = 1 -%>
```

```erb2slim``` command outputs a following wrong slim file.
```slim
- - a = 1
```