### PR TITLE
Convert to slim comment from erb comment

### DIFF
--- a/lib/html2slim/converter.rb
+++ b/lib/html2slim/converter.rb
@@ -27,6 +27,8 @@ module HTML2Slim
       # when
       erb.gsub!(/<%-?\s*(when .+?)\s*-?%>/){ %(</ruby><ruby code="#{$1.gsub(/"/, '&quot;')}">) }
       erb.gsub!(/<%\s*(end|}|end\s+-)\s*%>/, %(</ruby>))
+      # comment
+      erb.gsub!(/<%#\s*(.+?)%>/){ %(<erb_comment content="#{$1.gsub(/"/, '&quot;')}"></erb_comment>) }
       erb.gsub!(/<%(.+?)\s*-?%>/m){ %(<ruby code="#{$1.gsub(/"/, '&quot;')}"></ruby>) }
       @slim ||= Hpricot(erb).to_slim
     end

--- a/lib/html2slim/hpricot_monkeypatches.rb
+++ b/lib/html2slim/hpricot_monkeypatches.rb
@@ -50,6 +50,7 @@ class Hpricot::Elem
     r = '  ' * lvl
 
     return r + slim_ruby_code(r) if ruby?
+    return r + slim_comment(r) if comment?
 
     r += name unless skip_tag_name?
     r += slim_id
@@ -70,6 +71,10 @@ class Hpricot::Elem
 
   def slim_ruby_code(r)
     (code.strip[0] == "=" ? "" : "- ") + code.strip.gsub(/\n/, "\n#{r}- ")
+  end
+
+  def slim_comment(r)
+    "/ #{attributes['content']}"
   end
 
   def code
@@ -112,6 +117,10 @@ class Hpricot::Elem
 
   def div?
     name == "div"
+  end
+
+  def comment?
+    name == "erb_comment"
   end
 end
 

--- a/test/test_html2slim.rb
+++ b/test/test_html2slim.rb
@@ -115,6 +115,8 @@ class TestHTML2Slim < MiniTest::Test
     # until
     assert_erb_to_slim_with_and_without_leading_dash '<% until @foo.done? %>NEXT<% end %>',
                                                      "- until @foo.done?\n  | NEXT"
+    # comment
+    assert_erb_to_slim '<%# test comment %>', "/ test comment"
   end
 
   private


### PR DESCRIPTION
```erb
<%# test comment %>
```

The above erb converts to the following slim at present condition.

```slim
- # test comment
```

Slim has comment syntax.
```slim
/ test comment
```